### PR TITLE
Update recipe.yaml

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -5,5 +5,6 @@ output_format: 'https://gitlab-registry.cern.ch/unpacked/sync/$(image)'
 input:
     - 'https://registry.hub.docker.com/library/centos:centos7'
     - 'https://registry.hub.docker.com/engineren/ilcsoft:test'
+    - 'https://registry.hub.docker.com/uegede/weather:latest'
 
 


### PR DESCRIPTION
This image is used for tutorials for the Ganga User interface, https://github.com/ganga-devs/ganga.