### PR TITLE
add latest ldmx/dev image

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -39,3 +39,4 @@ input:
     - 'https://gitlab-p4n.aip.de:5005/compute4punch/container-stacks/lqcd_analysis:latest'
     - 'https://registry.hub.docker.com/augerobservatory/offline:latest'
     - 'https://registry.hub.docker.com/augerobservatory/augerdev:latest'
+    - 'https://registry.hub.docker.com/ldmx/dev:latest'


### PR DESCRIPTION
Only track the latest tag. We have other testing tags cluttering up the tag listing unfortunately and I'm unsure if this workflow will work well for our experiment. Putting just the latest tag in the unpacked.cern.ch repository of CVMFS will let us test run it in our cluster-based workflows.

Followed the instructions [online](https://cvmfs.readthedocs.io/en/stable/cpt-containers.html#using-unpacked-cern-ch) - hopefully I haven't made a mistake.