### PR TITLE
Add openmpi_alpine Docker image for CVMFS hosting

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -40,3 +40,4 @@ input:
     - 'https://registry.hub.docker.com/augerobservatory/offline:latest'
     - 'https://registry.hub.docker.com/augerobservatory/augerdev:latest'
     - 'https://registry.hub.docker.com/ligerlac/cicada:1.0-gpu'
+    - 'https://registry.hub.docker.com/mzrdocker/openmpi_alpine:latest'


### PR DESCRIPTION
The openmpi_alpine Docker image is a lightweight container designed to provide an all-in-one environment for running Message Passing Interface (MPI) applications using OpenMPI on the grid. 