### PR TITLE
Add ghcr.io/watonomous/actions-runner-image to recipe.yaml

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -42,5 +42,4 @@ input:
     - 'https://registry.hub.docker.com/augerobservatory/augerdev:latest'
     - 'https://registry.hub.docker.com/ligerlac/cicada:1.0-gpu'
     - 'https://registry.hub.docker.com/mzrdocker/openmpi_alpine:latest'
-    - 'https://ghcr.io/watonomous/actions-runner-image:main'
-    - 'https://ghcr.io/watonomous/actions-runner-image:pr-*'
+    - 'https://ghcr.io/watonomous/actions-runner-image:*'

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -42,3 +42,5 @@ input:
     - 'https://registry.hub.docker.com/augerobservatory/augerdev:latest'
     - 'https://registry.hub.docker.com/ligerlac/cicada:1.0-gpu'
     - 'https://registry.hub.docker.com/mzrdocker/openmpi_alpine:latest'
+    - 'https://ghcr.io/watonomous/actions-runner-image:main'
+    - 'https://ghcr.io/watonomous/actions-runner-image:pr-*'


### PR DESCRIPTION
This PR adds `ghcr.io/watonomous/actions-runner-image` to the recipe. We use this image for running GitHub Actions runners.